### PR TITLE
Add excludePatterns option. Improved collision handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Webpack Minimal Classnames
 
 Generate small css class names when using css modules with webpack css-loader.  
-Recommended to do only doing during production builds as a minification step.
+Recommended to do only doing during production builds as a minification step.  
+This differs from simply using css-loader's `[hash:base64:n]` by handling any collisions & allowing to configure excluded names.
 
 ### Example
 
@@ -19,10 +20,10 @@ Input:
 Output:
 
 ```css
-.gGd {
+.v8S {
   color: red;
 }
-._uJ {
+.dyv {
   color: green;
 }
 ```
@@ -31,6 +32,7 @@ Output:
 
 ```js
 const MinimalClassnameGenerator = require('webpack-minimal-classnames')
+const generateMinimalClassname = MinimalClassnameGenerator()
 
 {
   test: /\.css$/,
@@ -39,7 +41,7 @@ const MinimalClassnameGenerator = require('webpack-minimal-classnames')
       loader: 'css-loader',
       options: {
         modules: {
-          getLocalIdent: MinimalClassnameGenerator()
+          getLocalIdent: generateMinimalClassname
         }
       }
     }
@@ -49,9 +51,9 @@ const MinimalClassnameGenerator = require('webpack-minimal-classnames')
 
 ### Options
 
-**length**  
-default: 3
+**length** _(number)_ - Length of generated class names  
+default: 3  
+_If the max number of names is generated for a given length, it will start generating more at an incremented length_
 
-### Algorithm
-
-Webpack processes files in a non-deterministic async way so the order in which the classname minification is applied is different on every build. This means we can't simply increment a string/number because the output would be different each time (This is how it worked in 1.0). It works by generating a deterministic hash based on the filepath + local classname, shortens to 3 characters, and applies an incrementor incase of collisions.
+**excludePatterns** _(RegExp[])_ - Array of regex patterns to exclude generating as a class name  
+_NOTE: Automatically handles illegal css names_

--- a/index.js
+++ b/index.js
@@ -1,23 +1,19 @@
 const { createHash } = require('crypto')
 const { relative } = require('path')
 
-const CHARACTERS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_'
+const CHARACTERS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_-0123456789'
 const CHARACTERS_LEN = CHARACTERS.length
-
-function hash(string, length) {
-  const buffer = createHash('md5').update(string).digest().slice(0, length)
-
-  let value = ''
-  for (let i = 0, len = buffer.length; i < len; i++) {
-    value += CHARACTERS[buffer.readUInt8(i) % CHARACTERS_LEN]
-  }
-  return value
-}
+const REQUIRED_EXCLUDE_PATTERNS = [/^(\d|-)/] // Class names can't start with a digit or dash
 
 function MinimalClassnameGenerator(opts = {}) {
   const CACHE_MAP = {}
   const CACHE_VALUES = []
-  const { length = 3 } = opts
+  const { length = 3, excludePatterns = [] } = opts
+  const excludeRegexs = [...REQUIRED_EXCLUDE_PATTERNS, ...excludePatterns]
+  let currentLength = length
+  let maxValsForLength = Math.pow(CHARACTERS_LEN, currentLength)
+
+  if (length < 1) throw Error('[webpack-minimal-classnames] Option `length` must be >= 1')
 
   return function (context, _, localName) {
     const filepath = relative(context.rootContext, context.resourcePath)
@@ -25,16 +21,40 @@ function MinimalClassnameGenerator(opts = {}) {
     const cached = CACHE_MAP[key]
     if (cached) return cached
 
-    const baseClassname = hash(key, length)
-    let newClassname = baseClassname
-    let i = 0
-    while (CACHE_VALUES.includes(newClassname)) {
-      newClassname = baseClassname + i++
+    let className = hash(key, currentLength)
+    let retries = 0
+
+    // If there was already the same class name generated (collision), or it matches an exclude pattern
+    while (CACHE_VALUES.includes(className) || matchesRegexs(className, excludeRegexs)) {
+      // Try generating another name with an incremented key or length
+      className = hash(key + retries++, currentLength)
+      // If reached max possible values for the current length, make it longer and keep trying
+      if (retries >= maxValsForLength) {
+        maxValsForLength = Math.pow(CHARACTERS_LEN, ++currentLength)
+        retries = 0
+      }
     }
-    CACHE_MAP[key] = newClassname
-    CACHE_VALUES.push(newClassname)
-    return newClassname
+
+    CACHE_MAP[key] = className
+    CACHE_VALUES.push(className)
+    return className
   }
+}
+
+function hash(string, length) {
+  const buffer = createHash('md5').update(string).digest().slice(0, length)
+  let value = ''
+  for (let i = 0, len = buffer.length; i < len; i++) {
+    value += CHARACTERS[buffer.readUInt8(i) % CHARACTERS_LEN]
+  }
+  return value
+}
+
+function matchesRegexs(input, regexs) {
+  for (let i = 0, len = regexs.length; i < len; i++) {
+    if (regexs[i].test(input)) return true
+  }
+  return false
 }
 
 module.exports = MinimalClassnameGenerator

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webpack-minimal-classnames",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "webpack-minimal-classnames",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
         "css-loader": "^6.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-minimal-classnames",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Generate small css class names with webpack css-loader",
   "author": "Garth Poitras <garth22@gmail.com>",
   "repository": "https://github.com/neatsoftware/webpack-minimal-classnames",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3,12 +3,17 @@ const pkg = require('../package')
 const output = require('../dist/main')
 
 describe(pkg.name, () => {
-  it('genereates unique minimal classnames', () => {
-    assert.deepStrictEqual(output.style1.locals, { someClassnameBlah: 'jgM', fooBarBangBoom: 'CzG' })
+  it('genereates unique, legal minimal classnames', () => {
+    assert.deepStrictEqual(output.style1.locals, {
+      someLongDescriptiveCssClassName: 'v8S',
+      anotherLongDescriptiveCssClassName: 'dyv',
+      anotherOne: 'ubO',
+      test123__: 'udR'
+    })
   })
 
   it('genereates unique names if original classnames are the same but in different files', () => {
-    assert.deepStrictEqual(output.style2.locals, { someClassnameBlah: 'TWm' })
+    assert.deepStrictEqual(output.style2.locals, { someLongDescriptiveCssClassName: 'A_x' })
   })
 
   it('references the same classname when file is imported multiple times', () => {

--- a/test/test-app/style1.css
+++ b/test/test-app/style1.css
@@ -1,7 +1,17 @@
-.someClassnameBlah {
+.someLongDescriptiveCssClassName {
+  color: red;
+}
+
+.anotherLongDescriptiveCssClassName {
   color: green;
 }
 
-.fooBarBangBoom {
-  background: pink;
+/* NOTE: This class name naturally produces a hash starting with 'w', which is being used as an excludePatterns test */
+.anotherOne {
+  background: red;
+}
+
+/* NOTE: This class name naturally produces a hash starting with a number, which is being used to test that it's corrected to a legal class name */
+.test123__ {
+  background: green;
 }

--- a/test/test-app/style2.css
+++ b/test/test-app/style2.css
@@ -1,4 +1,4 @@
 /* test same class name but in different file/module */
-.someClassnameBlah {
-  color: red;
+.someLongDescriptiveCssClassName {
+  color: blue;
 }

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = {
             loader: 'css-loader',
             options: {
               modules: {
-                getLocalIdent: MinimalClassnameGenerator()
+                getLocalIdent: MinimalClassnameGenerator({ excludePatterns: [/^w/i] })
               }
             }
           }


### PR DESCRIPTION
- New option: `excludePatterns` accepts an array of regexs to exclude from generated class names. For example if you wanted `/ad/` to exclude that class name from being ad-blocked.
- Expanded the possible character alphabet & added built-in exclude patterns for illegal css class names
- Improved collision handling by increasing the class name length once the maximum number of names is generated. Opens possibility of setting the length to 1 for maximum minification.

Closes #3 